### PR TITLE
Add Time.allballs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Allballs
 
-Adds `allballs` alias for zero. Why not?
+Adds `allballs` alias for zero and `Time.allballs`. Why not?
 
 ## Installation
 
@@ -20,7 +20,8 @@ Or install it yourself as:
 
 ## Usage
 
-Add `include Allballs` to wherever you want to use `allballs`.
+Add `require "allballs/time"`, if you want a `Time.allballs` alias for epoch.
+Add `require "allballs/integer"`, if you want an integer `allballs` alias for `0`.
 
 ## Development
 

--- a/lib/allballs.rb
+++ b/lib/allballs.rb
@@ -1,9 +1,1 @@
 require "allballs/version"
-
-module Allballs
-  def zero
-    return 0;
-  end
-
-  alias allballs zero
-end

--- a/lib/allballs/integer.rb
+++ b/lib/allballs/integer.rb
@@ -1,0 +1,3 @@
+def allballs
+  return 0;
+end

--- a/lib/allballs/time.rb
+++ b/lib/allballs/time.rb
@@ -1,0 +1,17 @@
+require "allballs/version"
+require "time"
+
+module Allballs
+  ALLBALLS_TIME = Time.at(0)
+  ALLBALLS_TIME.freeze
+
+  module Time
+    def allballs
+      return ALLBALLS_TIME;
+    end
+  end
+end
+
+class Time
+  extend Allballs::Time
+end

--- a/lib/allballs/version.rb
+++ b/lib/allballs/version.rb
@@ -1,3 +1,3 @@
 module Allballs
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/test/allballs_integer_test.rb
+++ b/test/allballs_integer_test.rb
@@ -1,18 +1,17 @@
 require "test_helper"
+require "allballs/integer"
 
-class AllballsTest < Minitest::Test
-  include Allballs
-
+class AllballsIntegerTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Allballs::VERSION
   end
 
   def test_acts_like_numeric_zero
     addition = allballs + 5
-    assert(addition == 5, "Failed adding integer to allballs")
+    assert(addition == 5, "Failed adding integer to allballs: #{addition} != 5")
   end
 
   def test_equals_zero
-    assert(allballs == 0, "Does not return 0")
+    assert(allballs == 0, "Failed, #{allballs} != 0")
   end
 end

--- a/test/allballs_time_test.rb
+++ b/test/allballs_time_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+require "allballs/time"
+
+class AllballsTimeTest < Minitest::Test
+  def test_adds_allballs_to_Time
+    assert(Time.allballs.is_a?(::Time), "Failed, allballs is not a Time object: #{Time.allballs.class}")
+  end
+
+  def test_acts_like_time
+    one_minute_in_secs = 60_000_000
+    expected_time = Time.at(0) + one_minute_in_secs
+    advanced_time = Time.allballs + one_minute_in_secs
+    assert(advanced_time == expected_time, "Failed advancing allballs by 1 minute: expected #{expected_time}, got #{advanced_time}")
+  end
+
+  def test_equals_epoch
+    assert(Time.allballs == Time.at(0), "#{Time.allballs} != #{::Time.at(0)}")
+  end
+end


### PR DESCRIPTION
* Adds `Time.allballs`
* split allballs into modules.

How to use:
`require "allballs/integer" for `allballs` integer.
`require "allballs/time" for `Time.allballs`.
